### PR TITLE
fix:  TypeError: Cannot read property 'type' of undefined in detect-child-process rule (#69)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "eslint-plugin-security",
       "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/rules/detect-child-process.js
+++ b/rules/detect-child-process.js
@@ -41,7 +41,7 @@ module.exports = {
       },
       MemberExpression: function (node) {
         if (node.property.name === 'exec' && names.indexOf(node.object.name) > -1) {
-          if (node.parent && node.parent.arguments.length && node.parent.arguments[0].type !== 'Literal') {
+          if (node.parent && node.parent.arguments && node.parent.arguments.length > 0 && node.parent.arguments[0].type !== 'Literal') {
             return context.report(node, 'Found child_process.exec() with non Literal first argument');
           }
         }


### PR DESCRIPTION
Fixed TypeError of conflict between Mongoose `Query.exec()` and `child_process.exec()`.

#69