### PR TITLE
fix(detect-child-process): false positive for destructuring with `exec`

### DIFF
--- a/rules/detect-child-process.js
+++ b/rules/detect-child-process.js
@@ -9,11 +9,6 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-/*
- * Stores variable names pointing to child_process to check (child_process).exec()
- */
-const names = [];
-
 module.exports = {
   meta: {
     type: 'error',
@@ -25,22 +20,44 @@ module.exports = {
     },
   },
   create: function (context) {
+    /*
+     * Stores variable identifiers pointing to child_process to check (child_process).exec()
+     */
+    const childProcessIdentifiers = new Set();
+
+    /**
+     * Extract identifiers assigned the expression `require("child_process")`.
+     * @param {Pattern} node
+     */
+    function extractChildProcessIdentifiers(node) {
+      if (node.type !== 'Identifier') {
+        return;
+      }
+      const variable = context.getScope().set.get(node.name);
+      if (!variable) {
+        return;
+      }
+      for (const reference of variable.references) {
+        childProcessIdentifiers.add(reference.identifier);
+      }
+    }
+
     return {
       CallExpression: function (node) {
         if (node.callee.name === 'require') {
           const args = node.arguments[0];
           if (args && args.type === 'Literal' && args.value === 'child_process') {
             if (node.parent.type === 'VariableDeclarator') {
-              names.push(node.parent.id.name);
+              extractChildProcessIdentifiers(node.parent.id);
             } else if (node.parent.type === 'AssignmentExpression' && node.parent.operator === '=') {
-              names.push(node.parent.left.name);
+              extractChildProcessIdentifiers(node.parent.left);
             }
             return context.report({ node: node, message: 'Found require("child_process")' });
           }
         }
       },
       MemberExpression: function (node) {
-        if (node.property.name === 'exec' && names.indexOf(node.object.name) > -1) {
+        if (node.property.name === 'exec' && childProcessIdentifiers.has(node.object)) {
           if (node.parent && node.parent.arguments && node.parent.arguments.length && node.parent.arguments[0].type !== 'Literal') {
             return context.report({ node: node, message: 'Found child_process.exec() with non Literal first argument' });
           }

--- a/test/detect-child-process.js
+++ b/test/detect-child-process.js
@@ -36,6 +36,17 @@ tester.run(ruleName, rule, {
       code: `
       var foo = require('child_process');
       function fn () {
+        var result = foo.exec(str);
+      }`,
+      errors: [
+        { message: 'Found require("child_process")', line: 2 },
+        { message: 'Found child_process.exec() with non Literal first argument', line: 4 },
+      ],
+    },
+    {
+      code: `
+      var foo = require('child_process');
+      function fn () {
         var foo = /hello/;
         var result = foo.exec(str);
       }`,

--- a/test/detect-child-process.js
+++ b/test/detect-child-process.js
@@ -25,5 +25,21 @@ tester.run(ruleName, rule, {
       code: "var child = sinon.stub(require('child_process')); child.exec.returns({});",
       errors: [{ message: 'Found require("child_process")' }],
     },
+    {
+      code: `
+      var {} = require('child_process');
+      var result = /hello/.exec(str);`,
+      parserOptions: { ecmaVersion: 6 },
+      errors: [{ message: 'Found require("child_process")', line: 2 }],
+    },
+    {
+      code: `
+      var foo = require('child_process');
+      function fn () {
+        var foo = /hello/;
+        var result = foo.exec(str);
+      }`,
+      errors: [{ message: 'Found require("child_process")', line: 2 }],
+    },
   ],
 });


### PR DESCRIPTION
This PR fixes false positives in detect-child-process.

`detect-child-process` rule did not understand destructuring assignment and was incorrectly reporting non-identifier `exec()`.
This PR changes the `detect-child-process` rule to guard non-identifiers and correctly track variables.

fixes #64