### PR TITLE
fix(detect-child-process): false positives for destructuring `spawn`

### DIFF
--- a/rules/detect-child-process.js
+++ b/rules/detect-child-process.js
@@ -47,12 +47,18 @@ module.exports = {
         if (node.callee.name === 'require') {
           const args = node.arguments[0];
           if (args && args.type === 'Literal' && args.value === 'child_process') {
+            let pattern;
             if (node.parent.type === 'VariableDeclarator') {
-              extractChildProcessIdentifiers(node.parent.id);
+              pattern = node.parent.id;
             } else if (node.parent.type === 'AssignmentExpression' && node.parent.operator === '=') {
-              extractChildProcessIdentifiers(node.parent.left);
+              pattern = node.parent.left;
             }
-            return context.report({ node: node, message: 'Found require("child_process")' });
+            if (pattern) {
+              extractChildProcessIdentifiers(pattern);
+            }
+            if (!pattern || pattern.type === 'Identifier') {
+              return context.report({ node: node, message: 'Found require("child_process")' });
+            }
           }
         }
       },

--- a/test/detect-child-process.js
+++ b/test/detect-child-process.js
@@ -7,7 +7,19 @@ const ruleName = 'detect-child-process';
 const rule = require(`../rules/${ruleName}`);
 
 tester.run(ruleName, rule, {
-  valid: ["child_process.exec('ls')"],
+  valid: [
+    "child_process.exec('ls')",
+    {
+      code: `
+      var {} = require('child_process');
+      var result = /hello/.exec(str);`,
+      parserOptions: { ecmaVersion: 6 },
+    },
+    {
+      code: "var { spawn } = require('child_process'); spawn(str);",
+      parserOptions: { ecmaVersion: 6 },
+    },
+  ],
   invalid: [
     {
       code: "require('child_process')",
@@ -24,13 +36,6 @@ tester.run(ruleName, rule, {
     {
       code: "var child = sinon.stub(require('child_process')); child.exec.returns({});",
       errors: [{ message: 'Found require("child_process")' }],
-    },
-    {
-      code: `
-      var {} = require('child_process');
-      var result = /hello/.exec(str);`,
-      parserOptions: { ecmaVersion: 6 },
-      errors: [{ message: 'Found require("child_process")', line: 2 }],
     },
     {
       code: `


### PR DESCRIPTION
This PR fixes false positives in detect-child-process.

With this change, calls to `require("child_process")` will no longer be reported if destructuring assignment is used.

fixes #51