### PR TITLE
feat!: switch the recommended config to flat

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ yarn add --dev eslint-plugin-security
 
 ## Usage
 
-Add the following to your `.eslintrc` file:
+Add the following to your `eslint.config.js` file:
 
 ```js
-"extends": [
-  "plugin:security/recommended"
-]
+const pluginSecurity = require('eslint-plugin-security');
+
+module.exports = [pluginSecurity.configs.recommended];
 ```
 
 ## Developer guide

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
 
 const pkg = require('./package.json');
 
-module.exports = {
+const plugin = {
   meta: {
     name: pkg.name,
     version: pkg.version,
@@ -43,25 +43,29 @@ module.exports = {
     'detect-new-buffer': 0,
     'detect-bidi-characters': 0,
   },
-  configs: {
-    recommended: {
-      plugins: ['security'],
-      rules: {
-        'security/detect-buffer-noassert': 'warn',
-        'security/detect-child-process': 'warn',
-        'security/detect-disable-mustache-escape': 'warn',
-        'security/detect-eval-with-expression': 'warn',
-        'security/detect-new-buffer': 'warn',
-        'security/detect-no-csrf-before-method-override': 'warn',
-        'security/detect-non-literal-fs-filename': 'warn',
-        'security/detect-non-literal-regexp': 'warn',
-        'security/detect-non-literal-require': 'warn',
-        'security/detect-object-injection': 'warn',
-        'security/detect-possible-timing-attacks': 'warn',
-        'security/detect-pseudoRandomBytes': 'warn',
-        'security/detect-unsafe-regex': 'warn',
-        'security/detect-bidi-characters': 'warn',
-      },
-    },
+  configs: {}, // was assigned later so we can reference `plugin`
+};
+
+const recommended = {
+  plugins: { security: plugin },
+  rules: {
+    'security/detect-buffer-noassert': 'warn',
+    'security/detect-child-process': 'warn',
+    'security/detect-disable-mustache-escape': 'warn',
+    'security/detect-eval-with-expression': 'warn',
+    'security/detect-new-buffer': 'warn',
+    'security/detect-no-csrf-before-method-override': 'warn',
+    'security/detect-non-literal-fs-filename': 'warn',
+    'security/detect-non-literal-regexp': 'warn',
+    'security/detect-non-literal-require': 'warn',
+    'security/detect-object-injection': 'warn',
+    'security/detect-possible-timing-attacks': 'warn',
+    'security/detect-pseudoRandomBytes': 'warn',
+    'security/detect-unsafe-regex': 'warn',
+    'security/detect-bidi-characters': 'warn',
   },
 };
+
+Object.assign(plugin.configs, { recommended });
+
+module.exports = plugin;


### PR DESCRIPTION
This PR adds support for the [new eslint config](https://eslint.org/docs/latest/use/configure/configuration-files-new), an example:

```js
// eslint.config.js
const pluginSecurity = require('eslint-plugin-security');

module.exports = [pluginSecurity.configs.recommended];
```