### PR TITLE
fix: Ensure empty eval() doesn't crash detect-eval-with-expression

### DIFF
--- a/rules/detect-eval-with-expression.js
+++ b/rules/detect-eval-with-expression.js
@@ -19,10 +19,10 @@ module.exports = {
       url: 'https://github.com/eslint-community/eslint-plugin-security/blob/main/docs/rules/detect-eval-with-expression.md',
     },
   },
-  create: function (context) {
+  create(context) {
     return {
-      CallExpression: function (node) {
-        if (node.callee.name === 'eval' && node.arguments[0].type !== 'Literal') {
+      CallExpression(node) {
+        if (node.callee.name === 'eval' && node.arguments.length && node.arguments[0].type !== 'Literal') {
           context.report({ node: node, message: `eval with argument of type ${node.arguments[0].type}` });
         }
       },

--- a/test/rules/detect-eval-with-expression.js
+++ b/test/rules/detect-eval-with-expression.js
@@ -6,7 +6,7 @@ const tester = new RuleTester();
 const ruleName = 'detect-eval-with-expression';
 
 tester.run(ruleName, require(`../../rules/${ruleName}`), {
-  valid: [{ code: "eval('alert()')" }],
+  valid: [{ code: "eval('alert()')" }, { code: 'eval("some nefarious code");' }, { code: 'eval()' }],
   invalid: [
     {
       code: 'eval(a);',


### PR DESCRIPTION
fixes #138

Setting as draft pending response to https://github.com/eslint-community/eslint-plugin-security/issues/138#issuecomment-1942205808