### PR TITLE
ci: upgrade beemojs/conventional-pr-action v3

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,8 +12,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/setup-node@v3
-      - uses: beemojs/conventional-pr-action@v2
+      - uses: beemojs/conventional-pr-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          config-preset: angular
+          config-preset: conventional-changelog-conventionalcommits


### PR DESCRIPTION
it fixes the ci check failing, e.g. https://github.com/eslint-community/eslint-plugin-security/actions/runs/9499881665/job/26181774866