### PR TITLE
chore(.eslint-doc-generatorrc): add missing `'use strict'` directive

### DIFF
--- a/.eslint-doc-generatorrc.js
+++ b/.eslint-doc-generatorrc.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { format } = require('prettier');
 const prettierRC = require('./.prettierrc.json');
 


### PR DESCRIPTION
Adds a missing `'use strict'` directive to the only CJS file in this repo without one.