### PR TITLE
ci: update github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [18.18.0, 18.x, 20.x, 21.x]
+        node: [18.18.0, 18.x, 20.x, 22.x]
         include:
           - os: windows-latest
             node: lts/*

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,10 +8,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - uses: beemojs/conventional-pr-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,13 +17,13 @@ jobs:
           release-type: node
           package-name: test-release-please
       # The logic below handles the npm publication:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # these if statements ensure that a publication only occurs when
         # a new release is created:
         if: ${{ steps.release.outputs.release_created }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - run: npm ci


### PR DESCRIPTION
This PR bumps GitHub Actions to their latest major versions. Main change is they are now using Node 20 instead of 16, which was EOL as of April 2022:
   - Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
   - Releases for `actions/setup-node` can be [found here](https://github.com/actions/setup-node/releases)

At the same time, testing on EOL Node 21 has been swapped out for Node 22, and the package is now built in `release-please.yml` using node 18 rather than EOL Node 16.

